### PR TITLE
:children_crossing: (src): lift mouseUp events to app level

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -12,16 +12,21 @@ const App = ({
   onSetFrequency,
 }) => {
   return (
-    <WoolyWilly
-      amplitudes={amplitudes}
-      width={width}
-      height={height}
-      onGestureStart={onGestureStart}
-      onGestureEnd={onGestureEnd}
-      onMove={onMove}
-      frequency={frequency}
-      onSetFrequency={onSetFrequency}
-    />
+    <div
+      id="app"
+      onMouseUp={e => onGestureEnd()}
+      onTouchEnd={e => onGestureEnd()}
+    >
+      <WoolyWilly
+        amplitudes={amplitudes}
+        width={width}
+        height={height}
+        onGestureStart={onGestureStart}
+        onMove={onMove}
+        frequency={frequency}
+        onSetFrequency={onSetFrequency}
+      />
+    </div>
   )
 }
 

--- a/src/components/Oscilloscope.jsx
+++ b/src/components/Oscilloscope.jsx
@@ -10,7 +10,6 @@ const Oscilloscope = ({
   width,
   height,
   onGestureStart,
-  onGestureEnd,
   onMove,
 }) => {
   const stepSize = width / amplitudes.length
@@ -24,7 +23,6 @@ const Oscilloscope = ({
       width={width}
       height={height}
       onContentMousedown={e => onGestureStart([e.evt.layerX, e.evt.layerY])}
-      onContentMouseup={e => onGestureEnd()}
       onContentMousemove={e => onMove([
         e.evt.layerX,
         e.evt.layerY
@@ -33,7 +31,6 @@ const Oscilloscope = ({
         e.evt.targetTouches[0].clientX,
         e.evt.targetTouches[0].clientY,
       ])}
-      onContentTouchend={e => onGestureEnd()}
       onContentTouchmove={e => onMove([
         e.evt.targetTouches[0].clientX,
         e.evt.targetTouches[0].clientY,

--- a/src/components/WoolyWilly.jsx
+++ b/src/components/WoolyWilly.jsx
@@ -7,7 +7,6 @@ const WoolyWilly = ({
   width,
   height,
   onGestureStart,
-  onGestureEnd,
   onMove,
   frequency,
   onSetFrequency,
@@ -19,7 +18,6 @@ const WoolyWilly = ({
         width={width}
         height={height}
         onGestureStart={onGestureStart}
-        onGestureEnd={onGestureEnd}
         onMove={onMove}
       />
       <Frequency

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,10 @@ body {
   font-family: sans-serif;
 }
 
+#root, #app {
+  height: 100%;
+}
+
 .wooly-willy {
   max-width: 736px;
   margin: auto;
@@ -15,3 +19,4 @@ body {
   margin-bottom: 16px;
   border-radius: 4px;
 }
+


### PR DESCRIPTION
To fix #6. Listens for mouseUp across the app, but still only listens for mouseDown within the Oscilloscope.